### PR TITLE
Настройка CI с flake8 и pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Получение кода
+        uses: actions/checkout@v4
+      - name: Установка Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Установка зависимостей
+        run: |
+          pip install -r requirements-server.txt -r requirements-client.txt flake8 pytest
+      - name: Запуск flake8
+        run: flake8 .
+      - name: Запуск pytest
+        run: pytest

--- a/client/main.py
+++ b/client/main.py
@@ -108,7 +108,11 @@ def draw_board(
             pygame.draw.rect(screen, color, rect)
             piece = board.piece_at(row, col)
             if piece:
-                text = font.render(UNICODE_PIECES[piece], True, pygame.Color("black"))
+                text = font.render(
+                    UNICODE_PIECES[piece],
+                    True,
+                    pygame.Color("black"),
+                )
                 text_rect = text.get_rect(center=rect.center)
                 screen.blit(text, text_rect)
 
@@ -128,9 +132,13 @@ def main() -> None:
 
     def send_move(move: str) -> None:
         """Отправить ход на сервер и обработать ответ."""
-        nonlocal board, last_move, message, waiting
+        nonlocal last_move, message, waiting
         try:
-            payload = {"fen": board.fen, "side": board.side, "client_move": move}
+            payload = {
+                "fen": board.fen,
+                "side": board.side,
+                "client_move": move,
+            }
             response = httpx.post(f"{SERVER_URL}/move", json=payload)
             data = response.json()
             if data.get("new_fen"):
@@ -167,7 +175,11 @@ def main() -> None:
                 else:
                     move = coords_to_uci(*selected) + coords_to_uci(row, col)
                     waiting = True
-                    threading.Thread(target=send_move, args=(move,), daemon=True).start()
+                    threading.Thread(
+                        target=send_move,
+                        args=(move,),
+                        daemon=True,
+                    ).start()
                     selected = None
 
         draw_board(screen, board, last_move, selected)
@@ -176,7 +188,11 @@ def main() -> None:
             text = font.render(message, True, pygame.Color("red"))
             screen.blit(text, (5, WINDOW_SIZE - 20))
         if waiting:
-            wait_text = font.render("Ожидание...", True, pygame.Color("blue"))
+            wait_text = font.render(
+                "Ожидание...",
+                True,
+                pygame.Color("blue"),
+            )
             screen.blit(wait_text, (WINDOW_SIZE - 120, WINDOW_SIZE - 20))
         pygame.display.flip()
         clock.tick(30)

--- a/server/app/__init__.py
+++ b/server/app/__init__.py
@@ -2,3 +2,4 @@
 
 from .main import app
 
+__all__ = ["app"]

--- a/server/app/chess_logic.py
+++ b/server/app/chess_logic.py
@@ -9,7 +9,9 @@ import chess
 from .models import ErrorCode
 
 
-def validate_and_apply_move(fen: str, move: str) -> Tuple[Optional[chess.Board], List[ErrorCode]]:
+def validate_and_apply_move(
+    fen: str, move: str
+) -> Tuple[Optional[chess.Board], List[ErrorCode]]:
     """Проверить ход в формате UCI и применить его к позиции ``fen``.
 
     Parameters

--- a/server/main.py
+++ b/server/main.py
@@ -2,3 +2,4 @@
 
 from server.app import app
 
+__all__ = ["app"]

--- a/tests/test_chess_logic.py
+++ b/tests/test_chess_logic.py
@@ -9,7 +9,9 @@ def test_validate_and_apply_move_success():
     board, errors = validate_and_apply_move(chess.STARTING_FEN, "e2e4")
     assert not errors
     assert board is not None
-    assert board.fen() == "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1"
+    assert board.fen() == (
+        "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1"
+    )
 
 
 def test_validate_and_apply_move_illegal():

--- a/tests/test_new_game.py
+++ b/tests/test_new_game.py
@@ -8,4 +8,3 @@ def test_new_game(client):
     response = client.post("/new")
     assert response.status_code == 200
     assert response.json() == {"fen": chess.STARTING_FEN, "side": "w"}
-


### PR DESCRIPTION
## Summary
- В клиентском модуле разбиты длинные строки и убран лишний nonlocal【F:client/main.py†L111-L117】【F:client/main.py†L135-L141】
- В серверных модулях добавлены __all__ и устранены предупреждения об импорте【F:server/app/__init__.py†L1-L5】【F:server/main.py†L1-L5】
- Функция проверки хода и тесты приведены к ограничению длины строк PEP8【F:server/app/chess_logic.py†L12-L14】【F:tests/test_chess_logic.py†L9-L14】【F:tests/test_new_game.py†L6-L10】

## Testing
- ✅ `python -m flake8 .`【cd18e2†L1-L2】
- ✅ `pytest`【fb244f†L1-L7】

------
https://chatgpt.com/codex/tasks/task_e_689e4a816ea48320b77e7f856981069c