### PR TITLE
Добавлен таймаут в HTTP-запрос клиента

### DIFF
--- a/client/main.py
+++ b/client/main.py
@@ -147,7 +147,9 @@ def main() -> None:
                 "client_move": move,
             }
             logger.info("Отправка хода: %s", payload)
-            response = httpx.post(f"{SERVER_URL}/move", json=payload)
+            response = httpx.post(
+                f"{SERVER_URL}/move", json=payload, timeout=30.0
+            )
             data = response.json()
             logger.info("Ответ сервера: %s", data)
             if data.get("new_fen"):


### PR DESCRIPTION
## Изменения
- добавлен таймаут 30 секунд при отправке хода на сервер

## Тестирование
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e59d21d1883209306250c691ca272