### PR TITLE
fix: корректный импорт logging_config при запуске из подпапок

### DIFF
--- a/client/main.py
+++ b/client/main.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
+import logging
+import sys
 import threading
+from pathlib import Path
 from typing import Iterable
 
 import httpx
 import pygame
-import logging
 
-from logging_config import setup_logging
+# Добавляем корневую директорию проекта в путь поиска модулей
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from logging_config import setup_logging  # noqa: E402
 
 WHITE = (240, 217, 181)
 BROWN = (181, 136, 99)

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -1,9 +1,15 @@
 """Приложение FastAPI с эндпоинтом проверки состояния."""
 
-from logging_config import setup_logging
+import sys
+from pathlib import Path
+
 from fastapi import FastAPI
 
-from .routes import router
+# Добавляем корневую директорию проекта в путь поиска модулей
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from logging_config import setup_logging  # noqa: E402
+
+from .routes import router  # noqa: E402
 
 setup_logging()
 


### PR DESCRIPTION
## Summary
- исправлен поиск logging_config в клиенте
- то же решение добавлено в сервер

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e5bbdb51483208762201fe17c543c