### PR TITLE
Повторные попытки обращения к GPT и логирование резервного хода

### DIFF
--- a/server/app/gpt_client.py
+++ b/server/app/gpt_client.py
@@ -65,10 +65,10 @@ def get_ai_move(fen: str, legal_moves: List[str]) -> str:
             ai_move = response.output[0].content[0].text.strip()
         except Exception as exc:  # noqa: BLE001
             logger.error("Ошибка OpenAI API: %s", exc)
-            break
+            continue
         logger.info("Ответ GPT: %s", ai_move)
         if ai_move in legal_moves:
             return ai_move
     move = random.choice(legal_moves)
-    logger.info("Использован резервный случайный ход: %s", move)
+    logger.info("Превышен лимит повторов, выбран случайный ход: %s", move)
     return move

--- a/tests/server/test_gpt_client.py
+++ b/tests/server/test_gpt_client.py
@@ -5,8 +5,8 @@ from types import SimpleNamespace
 import server.app.gpt_client as gpt_client
 
 
-def test_invalid_response_falls_back(monkeypatch):
-    """Проверить, что возвращается ход из списка легальных."""
+def test_invalid_response_falls_back(monkeypatch, caplog):
+    """Проверить, что при превышении попыток используется резервный ход."""
 
     class DummyResponse:
         def __init__(self, text: str):
@@ -27,6 +27,43 @@ def test_invalid_response_falls_back(monkeypatch):
     monkeypatch.setattr(gpt_client.random, "choice", lambda seq: seq[0])
 
     legal_moves = ["a2a3", "b2b3"]
-    move = gpt_client.get_ai_move("8/8/8/8/8/8/8/8 w - - 0 1", legal_moves)
+    with caplog.at_level("INFO"):
+        move = gpt_client.get_ai_move(
+            "8/8/8/8/8/8/8/8 w - - 0 1", legal_moves
+        )
 
     assert move in legal_moves
+    assert "Превышен лимит повторов" in caplog.text
+
+
+def test_retries_on_exception(monkeypatch):
+    """Проверить, что при ошибке запроса выполняется повтор."""
+
+    class DummyResponse:
+        def __init__(self, text: str):
+            self.output = [
+                SimpleNamespace(
+                    content=[SimpleNamespace(text=text)],
+                )
+            ]
+
+    class DummyClient:
+        def __init__(self):
+            self.calls = 0
+            self.responses = SimpleNamespace(create=self._create)
+
+        def _create(self, **_):
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError("fail")
+            return DummyResponse("a2a3")
+
+    dummy = DummyClient()
+    monkeypatch.setattr(gpt_client, "_client", dummy)
+    monkeypatch.setattr(gpt_client, "_MAX_RETRIES", 2)
+
+    legal_moves = ["a2a3", "b2b3"]
+    move = gpt_client.get_ai_move("8/8/8/8/8/8/8/8 w - - 0 1", legal_moves)
+
+    assert move == "a2a3"
+    assert dummy.calls == 2


### PR DESCRIPTION
## Описание
- повторное выполнение запросов к GPT при ошибках
- журналирование выбора случайного хода после исчерпания попыток
- тесты для повторов и резервного хода

## Тестирование
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f366937c48320bf3962bfebdc791c