### PR TITLE
Не считать мат после хода игрока ошибкой

### DIFF
--- a/server/app/routes.py
+++ b/server/app/routes.py
@@ -86,12 +86,12 @@ async def move(request: MoveRequest) -> MoveResponse:
         if board.is_game_over():
             logger.info("Игра завершена после хода клиента")
             return MoveResponse(
-                status="error",
+                status="ok",
                 applied_client_move=True,
                 ai_move=None,
                 new_fen=board.fen(),
                 flags=Flags(**compute_game_flags(board)),
-                errors=[ErrorCode.NO_LEGAL_MOVES],
+                errors=[],
             )
 
     flags_before_ai = Flags(**compute_game_flags(board))

--- a/tests/server/test_game_endings.py
+++ b/tests/server/test_game_endings.py
@@ -34,7 +34,7 @@ def test_checkmate_detection(monkeypatch):
 
 
 def test_stalemate_detection(client):
-    """Ход клиента, ведущий к пату, должен быть зафиксирован."""
+    """Ход клиента, ведущий к пату, должен быть зафиксирован без ошибок."""
     payload = {
         "fen": "k7/1Q6/2K5/8/8/8/8/8 w - - 0 1",
         "side": "w",
@@ -43,12 +43,35 @@ def test_stalemate_detection(client):
     response = client.post("/move", json=payload)
     assert response.status_code == 200
     data = response.json()
-    assert data["status"] == "error"
-    assert data["errors"] == ["no_legal_moves"]
+    assert data["status"] == "ok"
+    assert data["errors"] == []
     assert data["flags"] == {
         "check": False,
         "checkmate": False,
         "stalemate": True,
+        "insufficient_material": False,
+        "seventyfive_moves": False,
+        "fivefold_repetition": False,
+    }
+
+
+def test_checkmate_after_client_move(client):
+    """Ход клиента, приводящий к мату, должен завершить игру без ошибок."""
+
+    payload = {
+        "fen": "k7/8/1QK5/8/8/8/8/8 w - - 0 1",
+        "side": "w",
+        "client_move": "b6b7",
+    }
+    response = client.post("/move", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ok"
+    assert data["errors"] == []
+    assert data["flags"] == {
+        "check": True,
+        "checkmate": True,
+        "stalemate": False,
         "insufficient_material": False,
         "seventyfive_moves": False,
         "fivefold_repetition": False,


### PR DESCRIPTION
## Summary
- Сервер больше не возвращает ошибку при завершении партии после хода клиента, даже при отсутствии легальных ходов【F:server/app/routes.py†L86-L95】
- Тесты обновлены: пат не считается ошибкой и добавлен сценарий мата после хода клиента【F:tests/server/test_game_endings.py†L36-L55】【F:tests/server/test_game_endings.py†L58-L78】

## Testing
- ✅ `flake8`【2a51e3†L1-L2】
- ✅ `pytest`【b80d46†L1-L19】

------
https://chatgpt.com/codex/tasks/task_e_689f3d42f88883208f42ba45afd949ed