### PR TITLE
Загрузка адреса сервера из окружения

### DIFF
--- a/client/config.py
+++ b/client/config.py
@@ -1,0 +1,7 @@
+"""Загрузка настроек клиента из переменных окружения."""
+
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+SERVER_URL = os.getenv("SERVER_URL", "http://localhost:8000")

--- a/client/main.py
+++ b/client/main.py
@@ -14,6 +14,7 @@ import pygame
 # Добавляем корневую директорию проекта в путь поиска модулей
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from client.chess_validation import validate_and_apply_move  # noqa: E402
+from client.config import SERVER_URL  # noqa: E402
 from logging_config import setup_logging  # noqa: E402
 
 WHITE = (240, 217, 181)
@@ -26,7 +27,6 @@ BOARD_SIZE = 8
 SQUARE_SIZE = 80
 WINDOW_SIZE = BOARD_SIZE * SQUARE_SIZE
 START_FEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
-SERVER_URL = "http://localhost:8000"
 
 UNICODE_PIECES = {
     "K": "\u2654",

--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -1,4 +1,5 @@
 pygame
 httpx
 python-chess
+python-dotenv
 

--- a/tests/client/test_config.py
+++ b/tests/client/test_config.py
@@ -1,0 +1,11 @@
+"""Тесты для модуля client.config."""
+
+import importlib
+
+
+def test_server_url_from_env(monkeypatch):
+    """Проверить чтение SERVER_URL из окружения."""
+    monkeypatch.setenv("SERVER_URL", "http://example.com")
+    import client.config as config
+    importlib.reload(config)
+    assert config.SERVER_URL == "http://example.com"


### PR DESCRIPTION
## Изменения
- вынес адрес сервера в модуль `client.config`
- подключил `SERVER_URL` в клиенте из конфигурации
- добавил зависимость `python-dotenv`
- добавил тест чтения `SERVER_URL`

## Проверки
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f89dbadc48320b6cd2a222105decb