### PR TITLE
Обновлена документация и добавлен CORS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,5 +2,5 @@
 OPENAI_API_KEY=<OPENAI_API_KEY>
 
 # Адрес сервера для клиента
-SERVER_URL=http://<PUBLIC_IP>:8000
+SERVER_URL=http://<PUBLIC_IP>:<PORT>
 

--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -124,4 +124,4 @@ flowchart LR
 ## 6) Security
 
 * GPT key is stored only on the server.
-* For MVP — run on a local PC or via tunnel (ngrok/Cloudflared).
+* For MVP — run on a local PC.

--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -124,4 +124,3 @@ flowchart LR
 ## 6) Security
 
 * GPT key is stored only on the server.
-* For MVP — run on a local PC.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ pip install -r requirements-client.txt
 ```bash
 cp .env.example .env
 # заполните OPENAI_API_KEY=<ваш ключ>
-# обязательно укажите SERVER_URL=http://localhost:8000
+# обязательно укажите SERVER_URL=http://<PUBLIC_IP>:<PORT>
 ```
 
 `SERVER_URL` задаёт адрес сервера. Значение обязательно; его можно хранить в `.env` (загружается через `python-dotenv`) или передавать при запуске.
@@ -55,24 +55,12 @@ cp .env.example .env
 ```bash
 uvicorn server.app:app --host 0.0.0.0 --port 8000 --env-file .env
 ```
-
-Чтобы открыть доступ из интернета, пробросьте порт через туннель:
-
-```bash
-cloudflared tunnel --url http://localhost:8000
-```
-
-или
-
-```bash
-ngrok http 8000
-```
-
-Полученный URL передайте клиенту через `SERVER_URL`.
+Сервер настроен с поддержкой CORS, поэтому к API можно обращаться с любого
+домена или IP.
 
 #### Эндпоинты
 
-- `GET /health` — проверка работоспособности.
+- `GET /health` — проверка работоспособности; возвращает `{ "status": "ok" }`.
 - `POST /move` — применяет ход игрока и возвращает ход ИИ.
 
 Пример запроса:
@@ -127,7 +115,7 @@ ngrok http 8000
 ### Клиент
 
 ```bash
-SERVER_URL=https://<твой-URL> python client/main.py
+SERVER_URL=http://<PUBLIC_IP>:<PORT> python client/main.py
 ```
 
 Если адрес сервера указан в `.env`, достаточно выполнить `python client/main.py`.
@@ -149,7 +137,7 @@ pyinstaller --onefile --name MiniGPTChess client/main.py
 При запуске укажите URL сервера:
 
 ```bash
-SERVER_URL=https://<твой-URL> ./dist/MiniGPTChess
+SERVER_URL=http://<PUBLIC_IP>:<PORT> ./dist/MiniGPTChess
 ```
 
 ## Тестирование

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -4,6 +4,7 @@ import sys
 from pathlib import Path
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 # Добавляем корневую директорию проекта в путь поиска модулей
 sys.path.append(str(Path(__file__).resolve().parents[2]))
@@ -14,6 +15,13 @@ from .routes import router  # noqa: E402
 setup_logging()
 
 app = FastAPI()
+# Включаем CORS, чтобы клиент мог обращаться с другого домена
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 app.include_router(router)
 
 


### PR DESCRIPTION
### Summary
- Из документации и AGENTS удалены ссылки на Cloudflare/ngrok и localhost; примеры и `.env` теперь используют формат `http://<PUBLIC_IP>:<PORT>`【F:AGENTS.MD†L127】【F:.env.example†L5】【F:README.md†L43】【F:README.md†L118】【F:README.md†L140】
- Добавлено краткое описание CORS и ответа `/health`, а сервер включает middleware для CORS【F:README.md†L58-L63】【F:server/app/main.py†L6-L24】

### Testing
- ✅ `flake8`【78199c†L1-L2】
- ✅ `pytest`【498d05†L1-L20】

------
https://chatgpt.com/codex/tasks/task_e_689facaf4b788320aeb81593c282ae10