### PR TITLE
Исправить использование max_tokens в клиенте GPT

### DIFF
--- a/server/app/gpt_client.py
+++ b/server/app/gpt_client.py
@@ -60,7 +60,7 @@ def get_ai_move(fen: str, legal_moves: List[str]) -> str:
                 input=prompt,
                 temperature=0,
                 top_p=1,
-                max_tokens=3,
+                max_output_tokens=3,
             )
             ai_move = response.output[0].content[0].text.strip()
         except Exception as exc:  # noqa: BLE001


### PR DESCRIPTION
## Summary
- Исправлен параметр запроса к OpenAI: вместо устаревшего `max_tokens` используется `max_output_tokens` для Responses API.

## Testing
- `python -m flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fbb6972b88320b7b85646138a12b2