### PR TITLE
Разделение .env для клиента и сервера

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,8 @@
             "type": "python",
             "request": "launch",
             "program": "${workspaceFolder}/client/main.py",
-            "console": "integratedTerminal"
+            "console": "integratedTerminal",
+            "envFile": "${workspaceFolder}/client/.env"
         },
         {
             "name": "Client Tests",
@@ -22,7 +23,7 @@
             "type": "python",
             "request": "launch",
             "module": "uvicorn",
-            "args": ["server.main:app", "--reload", "--env-file", ".env"],
+            "args": ["server.main:app", "--reload"],
             "console": "integratedTerminal"
         },
         {

--- a/README.md
+++ b/README.md
@@ -35,28 +35,36 @@ pip install -r requirements-client.txt
 
 ## Переменные окружения
 
-Создайте файл `.env` на основе `.env.example` и укажите ключи:
+У каждого компонента свои настройки.
+
+### Сервер
 
 ```bash
-cp .env.example .env
+cp server/.env.example server/.env
 # заполните OPENAI_API_KEY=<ваш ключ>
+```
+
+Дополнительно можно указать `CORS_ALLOW_ORIGINS` со списком доменов через запятую
+и включить подробные логи через `DEBUG_LOGS=1`.
+
+### Клиент
+
+```bash
+cp client/.env.example client/.env
 # обязательно укажите SERVER_URL=http://<PUBLIC_IP>:<PORT>
 ```
 
-`SERVER_URL` задаёт адрес сервера. Значение обязательно; его можно хранить в `.env` (загружается через `python-dotenv`) или передавать при запуске.
+`SERVER_URL` задаёт адрес сервера. Значение обязательно; его можно хранить в
+`client/.env` или передавать при запуске.
 
-Для включения подробных логов установите переменную окружения
-`DEBUG_LOGS=1` перед запуском клиента или сервера.
-
-Для ограничения доступа по CORS укажите `CORS_ALLOW_ORIGINS` со списком адресов
-через запятую. По умолчанию разрешены все источники.
+Переменная `DEBUG_LOGS=1` включает подробные логи клиента.
 
 ## Запуск
 
 ### Сервер
 
 ```bash
-uvicorn server.app:app --host 0.0.0.0 --port 8000 --env-file .env
+uvicorn server.main:app --host 0.0.0.0 --port 8000
 ```
 Сервер настроен с поддержкой CORS: по умолчанию API доступен с любого домена.
 Список доменов можно ограничить переменной `CORS_ALLOW_ORIGINS`.
@@ -121,7 +129,7 @@ uvicorn server.app:app --host 0.0.0.0 --port 8000 --env-file .env
 SERVER_URL=http://<PUBLIC_IP>:<PORT> python client/main.py
 ```
 
-Если адрес сервера указан в `.env`, достаточно выполнить `python client/main.py`.
+Если адрес сервера указан в `client/.env`, достаточно выполнить `python client/main.py`.
 
 Клиент отображает шахматную доску в стартовой позиции и взаимодействует с сервером для обмена ходами.
 
@@ -134,10 +142,9 @@ pip install pyinstaller
 pyinstaller --onefile --name MiniGPTChess client/main.py
 ```
 
-Готовый файл появится в каталоге `dist` (например, `dist/MiniGPTChess` или `MiniGPTChess.exe` на Windows). Передайте его вместе с этим каталогом и запускайте на машине, где уже работает сервер. Для получения папки с зависимостями используйте `pyinstaller --name MiniGPTChess client/main.py`; итоговая директория окажется в `dist/MiniGPTChess/`.
+Готовый файл появится в каталоге `dist` (например, `dist/MiniGPTChess` или `MiniGPTChess.exe` на Windows). Передайте его вместе с файлом `.env`, содержащим `SERVER_URL`, и запускайте на машине, где уже работает сервер. Для получения папки с зависимостями используйте `pyinstaller --name MiniGPTChess client/main.py`; итоговая директория окажется в `dist/MiniGPTChess/`.
 
-
-При запуске укажите URL сервера:
+Если переменная `SERVER_URL` не указана в `.env`, её можно передать при запуске:
 
 ```bash
 SERVER_URL=http://<PUBLIC_IP>:<PORT> ./dist/MiniGPTChess

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,6 +1,5 @@
-# Ключ OpenAI для генерации ходов
-OPENAI_API_KEY=<OPENAI_API_KEY>
-
 # Адрес сервера для клиента
 SERVER_URL=http://<PUBLIC_IP>:<PORT>
 
+# Включить подробные логи
+# DEBUG_LOGS=1

--- a/client/config.py
+++ b/client/config.py
@@ -1,12 +1,19 @@
 """Загрузка настроек клиента из переменных окружения."""
 
+from pathlib import Path
 import os
+import sys
 from dotenv import load_dotenv
 
-load_dotenv()
+if getattr(sys, "frozen", False):
+    base_dir = Path(sys.executable).resolve().parent
+else:
+    base_dir = Path(__file__).resolve().parent
+load_dotenv(base_dir / ".env")
+
 try:
     SERVER_URL = os.environ["SERVER_URL"]
 except KeyError as exc:
     raise RuntimeError(
-        "Переменная окружения SERVER_URL не задана"
+        "Переменная окружения SERVER_URL не задана",
     ) from exc

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -3,4 +3,5 @@ uvicorn
 python-chess
 openai
 pydantic
+python-dotenv
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,8 @@
+# Ключ OpenAI для генерации ходов
+OPENAI_API_KEY=<OPENAI_API_KEY>
+
+# Список доменов, которым разрешён доступ к API
+# CORS_ALLOW_ORIGINS=http://example.com,http://localhost:8000
+
+# Включить подробные логи
+# DEBUG_LOGS=1

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,1 +1,9 @@
-"""Server package containing API logic."""
+"""Пакет сервера для MiniGPTChess.
+
+Загружает переменные окружения из файла ``server/.env``.
+"""
+
+from pathlib import Path
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).resolve().parent / ".env")

--- a/tests/client/test_config.py
+++ b/tests/client/test_config.py
@@ -19,3 +19,18 @@ def test_missing_server_url_raises(monkeypatch):
     monkeypatch.delenv("SERVER_URL", raising=False)
     with pytest.raises(RuntimeError):
         importlib.reload(config)
+
+
+def test_server_url_from_file(monkeypatch):
+    """SERVER_URL должен считываться из client/.env."""
+    from pathlib import Path
+
+    env_path = Path(__file__).resolve().parents[2] / "client" / ".env"
+    env_path.write_text("SERVER_URL=http://fromfile\n")
+    try:
+        monkeypatch.delenv("SERVER_URL", raising=False)
+        import client.config as config
+        importlib.reload(config)
+        assert config.SERVER_URL == "http://fromfile"
+    finally:
+        env_path.unlink()


### PR DESCRIPTION
## Описание
- настроен сервер на загрузку переменных из `server/.env`
- клиент читает `client/.env` и onefile-билд ищет файл рядом с бинарником
- обновлены примеры и README

## Тестирование
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fcc0956388320806976e6fb70a906