### PR TITLE
Разделены конфигурации клиента и сервера

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,0 @@
-# Ключ OpenAI для генерации ходов
-OPENAI_API_KEY=<OPENAI_API_KEY>
-
-# Адрес сервера для клиента
-SERVER_URL=http://<PUBLIC_IP>:<PORT>
-

--- a/README.md
+++ b/README.md
@@ -35,28 +35,27 @@ pip install -r requirements-client.txt
 
 ## Переменные окружения
 
-Создайте файл `.env` на основе `.env.example` и укажите ключи:
+Сервер и клиент используют отдельные файлы конфигурации. Создайте их на основе примеров:
 
 ```bash
-cp .env.example .env
-# заполните OPENAI_API_KEY=<ваш ключ>
-# обязательно укажите SERVER_URL=http://<PUBLIC_IP>:<PORT>
+cp server/.env.example server/.env
+cp client/.env.example client/.env
+# в server/.env укажите OPENAI_API_KEY=<ваш ключ>
+# в client/.env укажите SERVER_URL=http://<PUBLIC_IP>:<PORT>
 ```
 
-`SERVER_URL` задаёт адрес сервера. Значение обязательно; его можно хранить в `.env` (загружается через `python-dotenv`) или передавать при запуске.
+`SERVER_URL` задаёт адрес сервера. Его можно хранить в `client/.env` или передавать при запуске.
 
-Для включения подробных логов установите переменную окружения
-`DEBUG_LOGS=1` перед запуском клиента или сервера.
+Для включения подробных логов установите `DEBUG_LOGS=1` в нужном `.env`.
 
-Для ограничения доступа по CORS укажите `CORS_ALLOW_ORIGINS` со списком адресов
-через запятую. По умолчанию разрешены все источники.
+Для ограничения доступа по CORS укажите `CORS_ALLOW_ORIGINS` в `server/.env` со списком адресов через запятую. По умолчанию разрешены все источники.
 
 ## Запуск
 
 ### Сервер
 
 ```bash
-uvicorn server.app:app --host 0.0.0.0 --port 8000 --env-file .env
+uvicorn server.app:app --host 0.0.0.0 --port 8000
 ```
 Сервер настроен с поддержкой CORS: по умолчанию API доступен с любого домена.
 Список доменов можно ограничить переменной `CORS_ALLOW_ORIGINS`.
@@ -121,7 +120,7 @@ uvicorn server.app:app --host 0.0.0.0 --port 8000 --env-file .env
 SERVER_URL=http://<PUBLIC_IP>:<PORT> python client/main.py
 ```
 
-Если адрес сервера указан в `.env`, достаточно выполнить `python client/main.py`.
+Если адрес сервера указан в `client/.env`, достаточно выполнить `python client/main.py`.
 
 Клиент отображает шахматную доску в стартовой позиции и взаимодействует с сервером для обмена ходами.
 
@@ -136,6 +135,7 @@ pyinstaller --onefile --name MiniGPTChess client/main.py
 
 Готовый файл появится в каталоге `dist` (например, `dist/MiniGPTChess` или `MiniGPTChess.exe` на Windows). Передайте его вместе с этим каталогом и запускайте на машине, где уже работает сервер. Для получения папки с зависимостями используйте `pyinstaller --name MiniGPTChess client/main.py`; итоговая директория окажется в `dist/MiniGPTChess/`.
 
+Файл `client/.env` необходимо разместить рядом с исполняемым файлом или добавить в сборку через `--add-data client/.env:.`.
 
 При запуске укажите URL сервера:
 

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,5 @@
+# Адрес сервера
+SERVER_URL=http://<PUBLIC_IP>:<PORT>
+
+# Включить подробные логи
+# DEBUG_LOGS=1

--- a/client/config.py
+++ b/client/config.py
@@ -1,9 +1,14 @@
 """Загрузка настроек клиента из переменных окружения."""
 
 import os
+import sys
+from pathlib import Path
+
 from dotenv import load_dotenv
 
-load_dotenv()
+# Определяем директорию, где искать файл `.env`
+_base_dir = Path(getattr(sys, "_MEIPASS", Path(__file__).resolve().parent))
+load_dotenv(_base_dir / ".env")
 try:
     SERVER_URL = os.environ["SERVER_URL"]
 except KeyError as exc:

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -3,4 +3,5 @@ uvicorn
 python-chess
 openai
 pydantic
+python-dotenv
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,8 @@
+# Ключ OpenAI для генерации ходов
+OPENAI_API_KEY=<OPENAI_API_KEY>
+
+# Список разрешённых источников CORS (необязательно)
+# CORS_ALLOW_ORIGINS=http://localhost:3000,http://example.com
+
+# Включить подробные логи
+# DEBUG_LOGS=1

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -4,8 +4,12 @@ import os
 import sys
 from pathlib import Path
 
+from dotenv import load_dotenv
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+
+load_dotenv(Path(__file__).resolve().parent.parent / ".env")
 
 # Добавляем корневую директорию проекта в путь поиска модулей
 sys.path.append(str(Path(__file__).resolve().parents[2]))


### PR DESCRIPTION
## Изменения
- сервер и клиент теперь читают `.env` из собственных каталогов
- добавлены примеры `client/.env.example` и `server/.env.example`
- обновлена документация и зависимости

## Тестирование
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fcee7af488320bd50c26f872f0966